### PR TITLE
vcpkg compatability update

### DIFF
--- a/JPEG.h
+++ b/JPEG.h
@@ -33,9 +33,15 @@ DAMAGE.
 
 #ifdef _WIN32
 #include <windows.h>
+#ifdef USE_VCPKG
+#include <jpeglib.h>
+#include <jerror.h>
+#include <jmorecfg.h>
+#else // USE_VCPKG
 #include "JPEG/jpeglib.h"
 #include "JPEG/jerror.h"
 #include "JPEG/jmorecfg.h"
+#endif // USE_VCPKG
 #else // !_WIN32
 #include <jpeglib.h>
 #include <jerror.h>

--- a/JPEG.inl
+++ b/JPEG.inl
@@ -31,9 +31,15 @@ DAMAGE.
 
 #ifdef _WIN32
 #include <windows.h>
+#ifdef USE_VCPKG
+#include <jpeglib.h>
+#include <jerror.h>
+#include <jmorecfg.h>
+#else // USE_VCPKG
 #include "JPEG/jpeglib.h"
 #include "JPEG/jerror.h"
 #include "JPEG/jmorecfg.h"
+#endif // USE_VCPKG
 #else // !_WIN32
 #include <jpeglib.h>
 #include <jerror.h>

--- a/PNG.h
+++ b/PNG.h
@@ -29,7 +29,11 @@ DAMAGE.
 #define PNG_INCLUDED
 
 #ifdef _WIN32
+#ifndef USE_VCPKG
 #include "PNG/png.h"
+#else // USE_VCPKG
+#include <png.h>
+#endif // USE_VCPKG
 #else // !_WIN32
 #include <png.h>
 #endif // _WIN32

--- a/PNG.inl
+++ b/PNG.inl
@@ -29,10 +29,15 @@ DAMAGE.
 #include <vector>
 #define NEW_ZLIB
 #ifdef _WIN32
+#ifdef USE_VCPKG
+#include <png.h>
+#include <zlib.h>
+#else // USE_VCPKG
 #include "PNG/png.h"
 #ifdef NEW_ZLIB
 #include "ZLIB/zlib.h"
 #endif // NEW_ZLIB
+#endif // USE_VCPKG
 #else // !_WIN32
 #include <png.h>
 #ifdef NEW_ZLIB


### PR DESCRIPTION
if zlib, libpng and libjpeg are installed using vcpkg, this will help compile if we define USE_VCPKG in the preprocessing.h