### PR TITLE
PNG/JPEG/ZLIB with vcpkg ("#define USE_VCPKG" to switch)

### DIFF
--- a/JPEG.h
+++ b/JPEG.h
@@ -34,9 +34,15 @@ DAMAGE.
 #include <setjmp.h>
 #ifdef _WIN32
 #include <windows.h>
+#ifdef USE_VCPKG
+#include <jpeglib.h>
+#include <jerror.h>
+#include <jmorecfg.h>
+#else // USE_VCPKG
 #include "JPEG/jpeglib.h"
 #include "JPEG/jerror.h"
 #include "JPEG/jmorecfg.h"
+#endif // USE_VCPKG
 #else // !_WIN32
 #include <jpeglib.h>
 #include <jerror.h>

--- a/PNG.h
+++ b/PNG.h
@@ -32,9 +32,17 @@ DAMAGE.
 #include <vector>
 #define NEW_ZLIB
 #ifdef _WIN32
+#ifndef USE_VCPKG
 #include "PNG/png.h"
+#else // USE_VCPKG
+#include <png.h>
+#endif // USE_VCPKG
 #ifdef NEW_ZLIB
+#ifdef USE_VCPKG
+#include <zlib.h>
+#else // USE_VCPKG
 #include "ZLIB/zlib.h"
+#endif // USE_VCPKG
 #endif // NEW_ZLIB
 #else // !_WIN32
 #include <png.h>


### PR DESCRIPTION
this should have zero effect if USE_VCPKG is not defined.